### PR TITLE
Add advanced args ability for hidden parameters 

### DIFF
--- a/docs/man.md
+++ b/docs/man.md
@@ -63,7 +63,7 @@ Use the `qpc-tools server install` command to install and configure the Quipucor
 
   Specifies the database user for PostgreSQL. Defaults to `postgres`.
 
-`--db-password`
+`--db-password=DB_PASSWORD`
 
   Specifies the database password for PostgreSQL.
 
@@ -71,7 +71,7 @@ Use the `qpc-tools server install` command to install and configure the Quipucor
 
   Sets the Quipucords server user name. Defaults to `admin`.
 
-`--password`
+`--password=SERVER_PASSSWORD`
 
   Sets the Quipucords server password.
 
@@ -91,7 +91,7 @@ If you choose the offline option to run the install command, you must do the fol
 1. Run qpc-tools with the required options to complete an offline installation.  For example:
 
     ```
-    qpc-tools server install --password --db-password --offline --offline-files='/PATH' --version=0.9.1
+    qpc-tools server install --offline --offline-files='/PATH' --version=0.9.1
     ```
 
 #### Installing a specific version of the server

--- a/qpc_tools/server/install.py
+++ b/qpc_tools/server/install.py
@@ -86,6 +86,7 @@ class InstallServerCommand(CliCommand):
                                  help=_(messages.SERVER_INSTALL_PASSWORD_HELP),
                                  required=False)
         self.parser.add_argument('--advanced', dest='server_advanced',
+                                 nargs='+', default=[],
                                  help=SUPPRESS,
                                  required=False)
 

--- a/qpc_tools/tests_util.py
+++ b/qpc_tools/tests_util.py
@@ -44,15 +44,17 @@ class UtilsTests(unittest.TestCase):
         playbook = os.path.join(cli_path, CLI_INSTALL_PLAYBOOK)
         base_online_install = Namespace(action='cli', cli_version=None,
                                         home_dir='~/quipucords', install_offline='false',
-                                        offline_files=None, server_advanced=None,
+                                        offline_files=None,
                                         server_host='127.0.0.1', server_port='9443',
                                         subcommand='install', verbosity=0,
                                         server_password='qpcpassw0rd',
-                                        db_password='password')
+                                        db_password='password',
+                                        server_advanced=['use_supervisord=False'])
         success_online = ['ansible-playbook', playbook,
                           '-vv', '-e home_dir=~/quipucords', '-e install_offline=false',
                           '-e server_host=127.0.0.1', '-e server_port=9443',
-                          '-e server_password=qpcpassw0rd', '-e db_password=password']
+                          '-e server_password=qpcpassw0rd', '-e db_password=password',
+                          '-e use_supervisord=False']
 
         cmd_list = utils.create_ansible_command(base_online_install, playbook)
         for cmd_part in cmd_list:

--- a/qpc_tools/utils.py
+++ b/qpc_tools/utils.py
@@ -104,16 +104,21 @@ def create_ansible_command(namespace_args, playbook):
     verbosity_lvl = '-vv'
     cmd_list.append(verbosity_lvl)
     # Filter Extra Vars
-    extra_vars = get_password(namespace_args.__dict__)
+    install_vars = get_password(namespace_args.__dict__)
     for key in NOT_ANSIBLE_KEYS:
-        if key in extra_vars.keys():
-            extra_vars.pop(key, None)
-    extra_vars = {k: v for k, v in extra_vars.items() if v is not None}
+        if key in install_vars.keys():
+            install_vars.pop(key, None)
+    # grab the advanced args
+    advanced_args = install_vars.pop('server_advanced', []) or []
+    install_vars = {k: v for k, v in install_vars.items() if v is not None}
     # Add extra vars to command
     extra_format = '-e %s=%s'
-    for key, value in extra_vars.items():
+    for key, value in install_vars.items():
         extra_var = extra_format % (key, value)
         cmd_list.append(extra_var)
+    # loop through advanced args and add them to the command
+    for advanced_cmd in advanced_args:
+        cmd_list.append('-e %s' % advanced_cmd)
     return cmd_list
 
 


### PR DESCRIPTION
Closes #29 

To test you can run: 
```
qpc-tools server install --advanced use_docker=True ansible_log_level=10 use_supervisord=false
```