### PR TITLE
Add logging for subprocess stderr, ansible command & cancel install

### DIFF
--- a/qpc_tools/cli/install.py
+++ b/qpc_tools/cli/install.py
@@ -85,11 +85,17 @@ class InstallCLICommand(CliCommand):
                 format_line = line.decode('utf-8').strip('\n')
                 print(format_line)
             # process.communicate performs a wait until playbooks is done
-            process.communicate()
+            stderr_data = process.communicate()[1]
             code = process.returncode
             if code == 0:
                 print(_(messages.CLI_INSTALLATION_SUCCESSFUL))
             else:
                 print(_(messages.CLI_INSTALLATION_FAILED))
+                if stderr_data != b'':
+                    format_stderr = stderr_data.decode('utf-8').strip('\n')
+                    if 'WARNING' not in format_stderr:
+                        print(_(messages.INSTALL_ERROR_MESSAGE % format_stderr))
         except ValueError:
             print(_(messages.CLI_INSTALLATION_FAILED))
+        except KeyboardInterrupt:
+            print(_(messages.INSTALLATION_CANCELED))

--- a/qpc_tools/messages.py
+++ b/qpc_tools/messages.py
@@ -47,5 +47,5 @@ CLI_INSTALL_PORT_HELP = 'Port number of the server'
 CLI_INSTALL_MUST_SPECIFY_PORT_AND_HOST = \
     'If either server-host or server-port are specified, both are required'
 INSTALL_ERROR_MESSAGE = 'The installation failed with the following message:\n %s'
-PLAYBOOK_COMMAND = 'Running this playbook command: \n %s'
+PLAYBOOK_COMMAND = 'Running the following playbook command: \n %s'
 INSTALLATION_CANCELED = '\n Installation canceled'

--- a/qpc_tools/messages.py
+++ b/qpc_tools/messages.py
@@ -22,7 +22,7 @@ ALL_INSTALL_HOME_DIR_HELP = 'The home directory for the Quipucords application d
 ALL_DIRECTORY_DOES_NOT_EXIST = "%s value '%s' does not exist"
 
 SERVER_INSTALLATION_SUCCESSFUL = 'Installation of server was successful'
-SERVER_INSTALLATION_FAILED = 'Server installation failed. Review the install logs'
+SERVER_INSTALLATION_FAILED = 'Server installation failed.'
 SERVER_INSTALL_OFFLINE_FILES_HELP = 'Specify the path to the server offline files'
 SERVER_INSTALL_VERSION_HELP = 'Specify the server version to install '\
     '(defaults to latest release)'
@@ -39,10 +39,13 @@ SERVER_INSTALL_REGISTRY_UN_HELP = 'Set the registry.redhat.io username'
 SERVER_INSTALL_REGISTRY_PASS_HELP = 'Set the registry.redhat.io password. '\
     'If not provided, user will be prompted.'
 CLI_INSTALLATION_SUCCESSFUL = 'Installation of CLI was successful'
-CLI_INSTALLATION_FAILED = 'CLI installation failed. Review the install logs'
+CLI_INSTALLATION_FAILED = 'CLI installation failed.'
 CLI_INSTALL_OFFLINE_FILES_HELP = 'Specify the path to the CLI offline files'
 CLI_INSTALL_VERSION_HELP = 'Specify the QPC CLI version to install (defaults to latest release)'
 CLI_INSTALL_SERVER_HELP = 'Host or IP address for the server'
 CLI_INSTALL_PORT_HELP = 'Port number of the server'
 CLI_INSTALL_MUST_SPECIFY_PORT_AND_HOST = \
     'If either server-host or server-port are specified, both are required'
+INSTALL_ERROR_MESSAGE = 'The installation failed with the following message:\n %s'
+PLAYBOOK_COMMAND = 'Running this playbook command: \n %s'
+INSTALLATION_CANCELED = '\n Installation canceled'

--- a/qpc_tools/server/install.py
+++ b/qpc_tools/server/install.py
@@ -106,11 +106,17 @@ class InstallServerCommand(CliCommand):
                 format_line = line.decode('utf-8').strip('\n')
                 print(format_line)
             # process.communicate performs a wait until playbooks is done
-            process.communicate()
+            stderr_data = process.communicate()[1]
             code = process.returncode
             if code == 0:
                 print(_(messages.SERVER_INSTALLATION_SUCCESSFUL))
             else:
                 print(_(messages.SERVER_INSTALLATION_FAILED))
+                if stderr_data != b'':
+                    format_stderr = stderr_data.decode('utf-8').strip('\n')
+                    if 'WARNING' not in format_stderr:
+                        print(_(messages.INSTALL_ERROR_MESSAGE % format_stderr))
         except ValueError:
             print(_(messages.SERVER_INSTALLATION_FAILED))
+        except KeyboardInterrupt:
+            print(_(messages.INSTALLATION_CANCELED))

--- a/qpc_tools/utils.py
+++ b/qpc_tools/utils.py
@@ -121,6 +121,14 @@ def create_ansible_command(namespace_args, playbook):
     # loop through advanced args and add them to the command
     for advanced_cmd in advanced_args:
         cmd_list.append('-e %s' % advanced_cmd)
+    # print command and mask passwords
+    tmp_list = cmd_list.copy()
+    for arg in tmp_list:
+        if 'password' in arg:
+            mask_arg = arg.split('=')[0] + '=' + '*******'
+            tmp_list.remove(arg)
+            tmp_list.append(mask_arg)
+    print(_(messages.PLAYBOOK_COMMAND % (' '.join(tmp_list))))
     return cmd_list
 
 


### PR DESCRIPTION
Closes #49 
🦉🦉🦉🦉🦉🦉🦉🦉 
#### Test One Critical Failure
We will need to create a critical failure which you can do by changing the `cmd_list.append(playbook)` to `cmd_list.append('fail.yml')`  in the `create_ansible_command` function in the utils.py
```
make clean
make setup-local-online
make test-all
sudo su
cd /qpc_tools/
make install-local-tools
qpc-tools cli install
```

#### Test Two: Check that the command is logged and that you can cancel without a stack trace.

⚠️  reset the utils.py so that the fatal error will go away

```
make clean
make setup-local-online
make test-all
sudo su
cd /qpc_tools/
make install-local-tools
qpc-tools server install --password pass
```
You should see: 
```
Running this playbook command:
 ansible-playbook /usr/local/lib/python3.6/site-packages/qpc_tools-0.1.2-py3.6.egg/qpc_tools/server/ansible/install/playbook.yml -vv -e server_port=9443 -e open_port=true -e db_user=postgres -e server_username=admin -e db_password=******* -e server_password=*******
```
Then cancel with control+C and you should see:
```
TASK [init : Create the Quipucords installation directory] *********************************************************************************************************************************************************************************************************************
task path: /usr/local/lib/python3.6/site-packages/qpc_tools-0.1.2-py3.6.egg/qpc_tools/server/ansible/install/roles/init/tasks/validate_params.yml:29
^C
 Installation canceled
```
#### Test that you can still login with the password you entered.
Restart the command with: 
```
qpc-tools server install --password pass --db-password pass
qpc-tools cli install --server-host 127.0.0.1 --server-port 9443
qpc server login 
```