### PR TITLE
Add an ordered dictionary to retain order of prompts

### DIFF
--- a/qpc_tools/utils.py
+++ b/qpc_tools/utils.py
@@ -163,10 +163,10 @@ def get_password(args_dictionary):
     :returns: the dictionary with updated passwords
     """
     arg_prompt = OrderedDict([
-        ('rh_registry_username', 'Enter registry.redhat.io username:'),
-        ('rh_registry_password', 'Enter registry.redhat.io password:'),
-        ('server_password', 'Enter server password:'),
-        ('db_password', 'Enter database password:')
+        ('rh_registry_username', 'Enter registry.redhat.io username: '),
+        ('rh_registry_password', 'Enter registry.redhat.io password: '),
+        ('server_password', 'Enter server password: '),
+        ('db_password', 'Enter database password: ')
     ])
     for arg, prompt in arg_prompt.items():
         if arg in args_dictionary and args_dictionary[arg] is None:

--- a/qpc_tools/utils.py
+++ b/qpc_tools/utils.py
@@ -16,6 +16,7 @@ from __future__ import print_function
 import logging
 import os
 import sys
+from collections import OrderedDict
 from getpass import getpass
 
 from qpc_tools import messages
@@ -161,12 +162,12 @@ def get_password(args_dictionary):
     :param args_dictionary: the dictionary containing the args and values
     :returns: the dictionary with updated passwords
     """
-    arg_prompt = {
-        'rh_registry_username': 'Enter registry.redhat.io username:',
-        'rh_registry_password': 'Enter registry.redhat.io password:',
-        'server_password': 'Enter server password:',
-        'db_password': 'Enter database password:'
-    }
+    arg_prompt = OrderedDict([
+        ('rh_registry_username', 'Enter registry.redhat.io username:'),
+        ('rh_registry_password', 'Enter registry.redhat.io password:'),
+        ('server_password', 'Enter server password:'),
+        ('db_password', 'Enter database password:')
+    ])
     for arg, prompt in arg_prompt.items():
         if arg in args_dictionary and args_dictionary[arg] is None:
             if arg == 'rh_registry_username':


### PR DESCRIPTION
Closes #51 

Should work the same except, passwords should always be prompted for in same order: 
Upstream: 
- server password 
- database password 

Downstream: 
- rh username 
- rh password 
- server password 
- db password