### PR TITLE
Change turn off server SSL validation for quipucords server image

### DIFF
--- a/qpc_tools/server/ansible/install/roles/server/tasks/download_quipucords_image_online.yml
+++ b/qpc_tools/server/ansible/install/roles/server/tasks/download_quipucords_image_online.yml
@@ -25,6 +25,7 @@
     url: "{{ quipucords_server_container_image_url }}"
     dest: "{{ server_packages }}"
     tmp_dest: "{{ server_packages }}"
+    validate_certs: no
     mode: 0644
     timeout: 300
   when:


### PR DESCRIPTION
Closes #62 

It turns out that you have to use get_url for large files.