### PR TITLE
Add args to support downstream installer installing from satellite

### DIFF
--- a/qpc-tools.spec
+++ b/qpc-tools.spec
@@ -67,7 +67,8 @@ install -D -p -m 644 docs/qpc-tools.1 %{buildroot}%{_mandir}/man1/qpc-tools.1
 
 %changelog
 * Thu Nov 14 2019 Kevan Holdaway <kholdawa@redhat.com> 0.2.2
-- Update version for master
+- Update version for master <kholdawa@redhat.com>
+- Add args to support installing from satellite downstream <cmyers@redhat.com>
 * Thu Nov 07 2019 Cody Myers <cmyers@redhat.com> 0.2.1
 - fix unintentional default var overwrite <cmyers@redhat.com>
 - Remove registry user from required args <cmyers@redhat.com>

--- a/qpc_tools/messages.py
+++ b/qpc_tools/messages.py
@@ -37,8 +37,8 @@ SERVER_INSTALL_DB_PASSWORD_HELP = 'Set the PostgreSQL DB password. If not provid
 SERVER_INSTALL_USERNAME_HELP = 'Set the server admin username (defaults to admin)'
 SERVER_INSTALL_PASSWORD_HELP = 'Set the server admin password. If not provided, '\
     'user will be prompted.'
-SERVER_INSTALL_REGISTRY_LOGIN_HELP = 'Indicate whether or not we should authenticate' \
-    ' with the container registry (defaults to true)'
+SERVER_INSTALL_REGISTRY_NO_AUTH_HELP = 'Indicates that the host machine ' \
+    'does not need to authenticate with container registry to pull images.'
 SERVER_INSTALL_REGISTRY_URL_HELP = 'Set the registry url (defaults to redhat.registry.io)'
 SERVER_INSTALL_REGISTRY_UN_HELP = 'Set the registry username. If '\
     'not provided, user will be prompted if registry login is required.'

--- a/qpc_tools/messages.py
+++ b/qpc_tools/messages.py
@@ -26,6 +26,8 @@ SERVER_INSTALLATION_FAILED = 'Server installation failed.'
 SERVER_INSTALL_OFFLINE_FILES_HELP = 'Specify the path to the server offline files'
 SERVER_INSTALL_VERSION_HELP = 'Specify the server version to install '\
     '(defaults to latest release)'
+SERVER_INSTALL_IMAGE_NAME = 'Sets the name of the server image. Defaults to the ' \
+    'latest discover-server name on redhat.registry.io'
 SERVER_INSTALL_PORT_HELP = 'Port number of the server (defaults to 9443)'
 SERVER_INSTALL_OPEN_PORT_HELP = "Indicate whether the host machine's port should be' \
     'opened (defaults to true)"
@@ -35,10 +37,13 @@ SERVER_INSTALL_DB_PASSWORD_HELP = 'Set the PostgreSQL DB password. If not provid
 SERVER_INSTALL_USERNAME_HELP = 'Set the server admin username (defaults to admin)'
 SERVER_INSTALL_PASSWORD_HELP = 'Set the server admin password. If not provided, '\
     'user will be prompted.'
-SERVER_INSTALL_REGISTRY_UN_HELP = 'Set the registry.redhat.io username. If '\
-    'not provided, user will be prompted.'
-SERVER_INSTALL_REGISTRY_PASS_HELP = 'Set the registry.redhat.io password. '\
-    'If not provided, user will be prompted.'
+SERVER_INSTALL_REGISTRY_LOGIN_HELP = 'Indicate whether or not we should authenticate' \
+    ' with the container registry (defaults to true)'
+SERVER_INSTALL_REGISTRY_URL_HELP = 'Set the registry url (defaults to redhat.registry.io)'
+SERVER_INSTALL_REGISTRY_UN_HELP = 'Set the registry username. If '\
+    'not provided, user will be prompted if registry login is required.'
+SERVER_INSTALL_REGISTRY_PASS_HELP = 'Set the registry password. '\
+    'If not provided, user will be prompted if registry login is required.'
 CLI_INSTALLATION_SUCCESSFUL = 'Installation of CLI was successful'
 CLI_INSTALLATION_FAILED = 'CLI installation failed.'
 CLI_INSTALL_OFFLINE_FILES_HELP = 'Specify the path to the CLI offline files'

--- a/qpc_tools/messages.py
+++ b/qpc_tools/messages.py
@@ -26,10 +26,6 @@ SERVER_INSTALLATION_FAILED = 'Server installation failed.'
 SERVER_INSTALL_OFFLINE_FILES_HELP = 'Specify the path to the server offline files'
 SERVER_INSTALL_VERSION_HELP = 'Specify the server version to install '\
     '(defaults to latest release)'
-SERVER_INSTALL_SERVER_IMAGE_HELP = 'Sets the name of the server image. Defaults to ' \
-    'the latest discover-server on redhat.registry.io'
-SERVER_INSTALL_DB_IMAGE_HELP = 'Sets the name of the DB image. Defaults to ' \
-    'the latest postgres96 on redhat.registry.io'
 SERVER_INSTALL_PORT_HELP = 'Port number of the server (defaults to 9443)'
 SERVER_INSTALL_OPEN_PORT_HELP = "Indicate whether the host machine's port should be' \
     'opened (defaults to true)"
@@ -39,13 +35,6 @@ SERVER_INSTALL_DB_PASSWORD_HELP = 'Set the PostgreSQL DB password. If not provid
 SERVER_INSTALL_USERNAME_HELP = 'Set the server admin username (defaults to admin)'
 SERVER_INSTALL_PASSWORD_HELP = 'Set the server admin password. If not provided, '\
     'user will be prompted.'
-SERVER_INSTALL_REGISTRY_NO_AUTH_HELP = 'Indicates that the host machine ' \
-    'does not need to authenticate with container registry to pull images.'
-SERVER_INSTALL_REGISTRY_URL_HELP = 'Set the registry url (defaults to redhat.registry.io)'
-SERVER_INSTALL_REGISTRY_UN_HELP = 'Set the registry username. If '\
-    'not provided, user will be prompted if registry login is required.'
-SERVER_INSTALL_REGISTRY_PASS_HELP = 'Set the registry password. '\
-    'If not provided, user will be prompted if registry login is required.'
 CLI_INSTALLATION_SUCCESSFUL = 'Installation of CLI was successful'
 CLI_INSTALLATION_FAILED = 'CLI installation failed.'
 CLI_INSTALL_OFFLINE_FILES_HELP = 'Specify the path to the CLI offline files'
@@ -57,3 +46,16 @@ CLI_INSTALL_MUST_SPECIFY_PORT_AND_HOST = \
 INSTALL_ERROR_MESSAGE = 'The installation failed with the following message:\n %s'
 PLAYBOOK_COMMAND = 'Running the following playbook command: \n %s'
 INSTALLATION_CANCELED = '\n Installation canceled'
+
+# the following message vars are for downstream use only
+SERVER_INSTALL_SERVER_IMAGE_HELP = 'Set the name of the server image. Defaults to ' \
+    'the latest discovery-server on redhat.registry.io'
+SERVER_INSTALL_DB_IMAGE_HELP = 'Set the name of the DB image. Defaults to ' \
+    'the latest postgres96 on redhat.registry.io'
+SERVER_INSTALL_REGISTRY_NO_AUTH_HELP = 'Indicates that the host machine ' \
+    'does not need to authenticate with container registry to pull images.'
+SERVER_INSTALL_REGISTRY_URL_HELP = 'Set the registry url (defaults to redhat.registry.io)'
+SERVER_INSTALL_REGISTRY_UN_HELP = 'Set the registry username. If '\
+    'not provided, user will be prompted if registry login is required.'
+SERVER_INSTALL_REGISTRY_PASS_HELP = 'Set the registry password. '\
+    'If not provided, user will be prompted if registry login is required.'

--- a/qpc_tools/messages.py
+++ b/qpc_tools/messages.py
@@ -26,8 +26,10 @@ SERVER_INSTALLATION_FAILED = 'Server installation failed.'
 SERVER_INSTALL_OFFLINE_FILES_HELP = 'Specify the path to the server offline files'
 SERVER_INSTALL_VERSION_HELP = 'Specify the server version to install '\
     '(defaults to latest release)'
-SERVER_INSTALL_IMAGE_NAME = 'Sets the name of the server image. Defaults to the ' \
-    'latest discover-server name on redhat.registry.io'
+SERVER_INSTALL_SERVER_IMAGE_HELP = 'Sets the name of the server image. Defaults to ' \
+    'the latest discover-server on redhat.registry.io'
+SERVER_INSTALL_DB_IMAGE_HELP = 'Sets the name of the DB image. Defaults to ' \
+    'the latest postgres96 on redhat.registry.io'
 SERVER_INSTALL_PORT_HELP = 'Port number of the server (defaults to 9443)'
 SERVER_INSTALL_OPEN_PORT_HELP = "Indicate whether the host machine's port should be' \
     'opened (defaults to true)"

--- a/qpc_tools/server/ansible/install/playbook.yml
+++ b/qpc_tools/server/ansible/install/playbook.yml
@@ -9,6 +9,7 @@
       server_port: '9443'
       server_name: 'quipucords'
       postgres_version: '9.6.10'
+      db_image_name: 'postgres'
       server_image_name: 'quipucords'
       server_image_tag: ''
       registry_url: 'registry.redhat.io'

--- a/qpc_tools/server/ansible/install/playbook.yml
+++ b/qpc_tools/server/ansible/install/playbook.yml
@@ -11,6 +11,7 @@
       postgres_version: '9.6.10'
       server_image_name: 'quipucords'
       server_image_tag: ''
+      registry_url: 'registry.redhat.io'
       podman_tls_verify: 'true'
       db_name: 'qpc-db'
       server_username: 'admin'

--- a/qpc_tools/server/ansible/install/roles/server/tasks/validate_params.yml
+++ b/qpc_tools/server/ansible/install/roles/server/tasks/validate_params.yml
@@ -14,14 +14,6 @@
     - not open_port|lower == 'true'
     - not open_port|lower == 'false'
 
-- name: Validate registry_login is set to true or false
-  fail:
-    msg: "{{ registry_login }} is invalid value for registry_login.  Must be equal to true or false"
-  when:
-    - registry_login is defined
-    - not registry_login|lower == 'true'
-    - not registry_login|lower == 'false'
-
 - name: Validate Quipucords server version compatibility with RHEL 8
   fail:
     msg: "Quipucords server {{ server_version }} cannot be installed on RHEL 8.  RHEL 8 requires version 0.9.1 or newer."

--- a/qpc_tools/server/ansible/install/roles/server/tasks/validate_params.yml
+++ b/qpc_tools/server/ansible/install/roles/server/tasks/validate_params.yml
@@ -14,6 +14,14 @@
     - not open_port|lower == 'true'
     - not open_port|lower == 'false'
 
+- name: Validate registry_login is set to true or false
+  fail:
+    msg: "{{ registry_login }} is invalid value for registry_login.  Must be equal to true or false"
+  when:
+    - registry_login is defined
+    - not registry_login|lower == 'true'
+    - not registry_login|lower == 'false'
+
 - name: Validate Quipucords server version compatibility with RHEL 8
   fail:
     msg: "Quipucords server {{ server_version }} cannot be installed on RHEL 8.  RHEL 8 requires version 0.9.1 or newer."
@@ -24,7 +32,7 @@
 
 - name: Fail if podman command not found when podman is being used instead of docker
   fail:
-    msg: "Podman command not found and "
+    msg: "Podman command not found"
   ignore_errors: true
   when:
     - use_docker|lower == 'false'

--- a/qpc_tools/server/ansible/install/roles/server_docker/tasks/start_postgres_container.yml
+++ b/qpc_tools/server/ansible/install/roles/server_docker/tasks/start_postgres_container.yml
@@ -1,13 +1,13 @@
 ---
 
 - name: Start PostgreSQL container with docker volume on RHEL 6 or CentOS 6
-  shell: "docker run --name {{ db_name }}  -e POSTGRES_USER={{ db_user }} -e POSTGRES_PASSWORD='{{ db_password }}' -v /var/lib/docker/volumes/qpc-data:/var/lib/postgresql/data -d postgres:{{postgres_version}}"
+  shell: "docker run --name {{ db_name }}  -e POSTGRES_USER={{ db_user }} -e POSTGRES_PASSWORD='{{ db_password }}' -v /var/lib/docker/volumes/qpc-data:/var/lib/postgresql/data -d {{db_image_name}}:{{postgres_version}}"
   become: true
   when:
     - is_rhel_centos_6|bool
 
 - name: Start PostgreSQL container with docker volume on RHEL 7 or CentOS 7
-  shell: "docker run --name {{ db_name }}  -e POSTGRES_USER={{ db_user }} -e POSTGRES_PASSWORD='{{ db_password }}' -v qpc-data:/var/lib/postgresql/data -d postgres:{{postgres_version}}"
+  shell: "docker run --name {{ db_name }}  -e POSTGRES_USER={{ db_user }} -e POSTGRES_PASSWORD='{{ db_password }}' -v qpc-data:/var/lib/postgresql/data -d {{db_image_name}}:{{postgres_version}}"
   become: true
   when:
     - is_rhel_centos_7|bool

--- a/qpc_tools/server/ansible/install/roles/server_podman/tasks/install_online.yml
+++ b/qpc_tools/server/ansible/install/roles/server_podman/tasks/install_online.yml
@@ -44,8 +44,9 @@
     name: server_podman
     tasks_from: redhat_registry
   when:
-    - rh_registry_username is defined
-    - rh_registry_password is defined
+    - registry_username is defined
+    - registry_password is defined
+    - registry_login|bool
 
 - name: Download server image from GitHub
   include_role:

--- a/qpc_tools/server/ansible/install/roles/server_podman/tasks/install_online.yml
+++ b/qpc_tools/server/ansible/install/roles/server_podman/tasks/install_online.yml
@@ -46,7 +46,7 @@
   when:
     - registry_username is defined
     - registry_password is defined
-    - registry_login|bool
+    - registry_no_auth is not defined
 
 - name: Download server image from GitHub
   include_role:

--- a/qpc_tools/server/ansible/install/roles/server_podman/tasks/redhat_registry.yml
+++ b/qpc_tools/server/ansible/install/roles/server_podman/tasks/redhat_registry.yml
@@ -1,12 +1,12 @@
 ---
 
-- name: Login to redhat registry with podman
-  shell: "podman login -u '{{rh_registry_username}}' -p '{{rh_registry_password}}' registry.redhat.io"
-  register: rh_registry_login_attempt
+- name: Login to registry with podman
+  shell: "podman login -u '{{registry_username}}' -p '{{registry_password}}' '{{registry_url}}'"
+  register: registry_login_attempt
   ignore_errors: True
   no_log: True
 
 - fail:
-    msg: "Login attempt failed. Log in manually with `podman login registry.redhat.io`"
+    msg: "Login attempt failed. Log in manually with `podman login {{registry_url}}`"
   when:
-    - rh_registry_login_attempt.rc != 0
+    - registry_login_attempt.rc != 0

--- a/qpc_tools/server/ansible/install/roles/server_podman/tasks/start_postgres_container.yml
+++ b/qpc_tools/server/ansible/install/roles/server_podman/tasks/start_postgres_container.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Start PostgreSQL container with Podman
-  shell: "podman run --name {{ db_name }} --network=container:{{ server_name }} -e POSTGRES_USER={{ db_user }} -e POSTGRES_PASSWORD='{{ db_password }}' -v qpc-data:/var/lib/postgresql/data -d postgres:{{postgres_version}}"
+  shell: "podman run --name {{ db_name }} --network=container:{{ server_name }} -e POSTGRES_USER={{ db_user }} -e POSTGRES_PASSWORD='{{ db_password }}' -v qpc-data:/var/lib/postgresql/data -d {{db_image_name}}:{{postgres_version}}"
   become: true
 
 - name: Waiting for PostgreSQL to spin up

--- a/qpc_tools/server/install.py
+++ b/qpc_tools/server/install.py
@@ -42,9 +42,6 @@ class InstallServerCommand(CliCommand):
         if DOWNSTREAM:
             # Be careful adding defaults here, because it would require a new
             # upstream release to change the downstream defaults.
-            self.parser.add_argument('--image-name', dest='server_image_name',
-                                     help=_(messages.SERVER_INSTALL_IMAGE_NAME),
-                                     required=False)
             self.parser.add_argument('--registry-no-auth', dest='registry_no_auth',
                                      action='store_true',
                                      help=_(messages.SERVER_INSTALL_REGISTRY_NO_AUTH_HELP),
@@ -58,6 +55,12 @@ class InstallServerCommand(CliCommand):
                                      required=False)
             self.parser.add_argument('--registry-password', dest='registry_password',
                                      help=_(messages.SERVER_INSTALL_REGISTRY_PASS_HELP),
+                                     required=False)
+            self.parser.add_argument('--server-image-name', dest='server_image_name',
+                                     help=_(messages.SERVER_INSTALL_SERVER_IMAGE_HELP),
+                                     required=False)
+            self.parser.add_argument('--db-image-name', dest='server_image_name',
+                                     help=_(messages.SERVER_INSTALL_DB_IMAGE_HELP),
                                      required=False)
         else:
             # Upstream only args

--- a/qpc_tools/server/install.py
+++ b/qpc_tools/server/install.py
@@ -59,7 +59,7 @@ class InstallServerCommand(CliCommand):
             self.parser.add_argument('--server-image-name', dest='server_image_name',
                                      help=_(messages.SERVER_INSTALL_SERVER_IMAGE_HELP),
                                      required=False)
-            self.parser.add_argument('--db-image-name', dest='server_image_name',
+            self.parser.add_argument('--db-image-name', dest='db_image_name',
                                      help=_(messages.SERVER_INSTALL_DB_IMAGE_HELP),
                                      required=False)
         else:

--- a/qpc_tools/server/install.py
+++ b/qpc_tools/server/install.py
@@ -45,10 +45,9 @@ class InstallServerCommand(CliCommand):
             self.parser.add_argument('--image-name', dest='server_image_name',
                                      help=_(messages.SERVER_INSTALL_IMAGE_NAME),
                                      required=False)
-            self.parser.add_argument('--registry-login', dest='registry_login',
-                                     choices=BOOLEAN_CHOICES,
-                                     default='true',
-                                     help=_(messages.SERVER_INSTALL_REGISTRY_LOGIN_HELP),
+            self.parser.add_argument('--registry-no-auth', dest='registry_no_auth',
+                                     action='store_true',
+                                     help=_(messages.SERVER_INSTALL_REGISTRY_NO_AUTH_HELP),
                                      required=False)
             self.parser.add_argument('--registry-url', dest='registry_url',
                                      default='registry.redhat.io',

--- a/qpc_tools/server/install.py
+++ b/qpc_tools/server/install.py
@@ -40,10 +40,24 @@ class InstallServerCommand(CliCommand):
         CliCommand.__init__(self, self.SUBCOMMAND, self.ACTION,
                             subparsers.add_parser(self.ACTION))
         if DOWNSTREAM:
-            self.parser.add_argument('--registry-user', dest='rh_registry_username',
+            # Be careful adding defaults here, because it would require a new
+            # upstream release to change the downstream defaults.
+            self.parser.add_argument('--image-name', dest='server_image_name',
+                                     help=_(messages.SERVER_INSTALL_IMAGE_NAME),
+                                     required=False)
+            self.parser.add_argument('--registry-login', dest='registry_login',
+                                     choices=BOOLEAN_CHOICES,
+                                     default='true',
+                                     help=_(messages.SERVER_INSTALL_REGISTRY_LOGIN_HELP),
+                                     required=False)
+            self.parser.add_argument('--registry-url', dest='registry_url',
+                                     default='registry.redhat.io',
+                                     help=_(messages.SERVER_INSTALL_REGISTRY_URL_HELP),
+                                     required=False)
+            self.parser.add_argument('--registry-user', dest='registry_username',
                                      help=_(messages.SERVER_INSTALL_REGISTRY_UN_HELP),
                                      required=False)
-            self.parser.add_argument('--registry-password', dest='rh_registry_password',
+            self.parser.add_argument('--registry-password', dest='registry_password',
                                      help=_(messages.SERVER_INSTALL_REGISTRY_PASS_HELP),
                                      required=False)
         else:

--- a/qpc_tools/tests_util.py
+++ b/qpc_tools/tests_util.py
@@ -153,7 +153,7 @@ class UtilsTests(unittest.TestCase):
 
     @mock.patch('qpc_tools.utils.getpass')
     def test_register_no_auth(self, input_mock):
-        """Test that we prompt for username if it is None."""
+        """Test that registry_no_auth doesn't prompt for info."""
         input_mock.return_value = 'pass'
         args_dictionary = {'server_password': None,
                            'registry_no_auth': True}

--- a/qpc_tools/tests_util.py
+++ b/qpc_tools/tests_util.py
@@ -147,9 +147,18 @@ class UtilsTests(unittest.TestCase):
     def test_get_username(self, input_mock):
         """Test that we prompt for username if it is None."""
         input_mock.return_value = 'admin'
-        args_dictionary = {'rh_registry_username': None}
+        args_dictionary = {'registry_username': None}
         updated_dictionary = utils.get_password(args_dictionary)
-        self.assertEqual(updated_dictionary['rh_registry_username'], 'admin')
+        self.assertEqual(updated_dictionary['registry_username'], 'admin')
+
+    @mock.patch('qpc_tools.utils.getpass')
+    def test_register_login_false(self, input_mock):
+        """Test that we prompt for username if it is None."""
+        input_mock.return_value = 'pass'
+        args_dictionary = {'server_password': None,
+                           'registry_login': 'false'}
+        updated_dictionary = utils.get_password(args_dictionary)
+        self.assertEqual(updated_dictionary['server_password'], 'pass')
 
     def test_check_offline(self):
         """Test the check offline function."""

--- a/qpc_tools/tests_util.py
+++ b/qpc_tools/tests_util.py
@@ -152,11 +152,11 @@ class UtilsTests(unittest.TestCase):
         self.assertEqual(updated_dictionary['registry_username'], 'admin')
 
     @mock.patch('qpc_tools.utils.getpass')
-    def test_register_login_false(self, input_mock):
+    def test_register_no_auth(self, input_mock):
         """Test that we prompt for username if it is None."""
         input_mock.return_value = 'pass'
         args_dictionary = {'server_password': None,
-                           'registry_login': 'false'}
+                           'registry_no_auth': True}
         updated_dictionary = utils.get_password(args_dictionary)
         self.assertEqual(updated_dictionary['server_password'], 'pass')
 

--- a/qpc_tools/utils.py
+++ b/qpc_tools/utils.py
@@ -170,7 +170,7 @@ def get_password(args_dictionary):
     :param args_dictionary: the dictionary containing the args and values
     :returns: the dictionary with updated passwords
     """
-    if args_dictionary.get('registry_login') in ['false', 'False']:
+    if args_dictionary.get('registry_no_auth'):
         arg_prompt = OrderedDict([
             ('server_password', 'Enter server password: '),
             ('db_password', 'Enter database password: ')

--- a/qpc_tools/utils.py
+++ b/qpc_tools/utils.py
@@ -176,9 +176,10 @@ def get_password(args_dictionary):
             ('db_password', 'Enter database password: ')
         ])
     else:
+        registry_url = args_dictionary.get('registry_url', 'registry url')
         arg_prompt = OrderedDict([
-            ('registry_username', 'Enter container registry username: '),
-            ('registry_password', 'Enter container registry password: '),
+            ('registry_username', 'Enter %s username: ' % registry_url),
+            ('registry_password', 'Enter %s password: ' % registry_url),
             ('server_password', 'Enter server password: '),
             ('db_password', 'Enter database password: ')
         ])

--- a/qpc_tools/utils.py
+++ b/qpc_tools/utils.py
@@ -176,7 +176,7 @@ def get_password(args_dictionary):
             ('db_password', 'Enter database password: ')
         ])
     else:
-        registry_url = args_dictionary.get('registry_url', 'registry url')
+        registry_url = args_dictionary.get('registry_url')
         arg_prompt = OrderedDict([
             ('registry_username', 'Enter %s username: ' % registry_url),
             ('registry_password', 'Enter %s password: ' % registry_url),

--- a/qpc_tools/utils.py
+++ b/qpc_tools/utils.py
@@ -170,15 +170,21 @@ def get_password(args_dictionary):
     :param args_dictionary: the dictionary containing the args and values
     :returns: the dictionary with updated passwords
     """
-    arg_prompt = OrderedDict([
-        ('rh_registry_username', 'Enter registry.redhat.io username: '),
-        ('rh_registry_password', 'Enter registry.redhat.io password: '),
-        ('server_password', 'Enter server password: '),
-        ('db_password', 'Enter database password: ')
-    ])
+    if args_dictionary.get('registry_login') in ['false', 'False']:
+        arg_prompt = OrderedDict([
+            ('server_password', 'Enter server password: '),
+            ('db_password', 'Enter database password: ')
+        ])
+    else:
+        arg_prompt = OrderedDict([
+            ('registry_username', 'Enter registry.redhat.io username: '),
+            ('registry_password', 'Enter registry.redhat.io password: '),
+            ('server_password', 'Enter server password: '),
+            ('db_password', 'Enter database password: ')
+        ])
     for arg, prompt in arg_prompt.items():
         if arg in args_dictionary and args_dictionary[arg] is None:
-            if arg == 'rh_registry_username':
+            if arg == 'registry_username':
                 arg_value = input(prompt)
             else:
                 arg_value = None

--- a/qpc_tools/utils.py
+++ b/qpc_tools/utils.py
@@ -177,8 +177,8 @@ def get_password(args_dictionary):
         ])
     else:
         arg_prompt = OrderedDict([
-            ('registry_username', 'Enter registry.redhat.io username: '),
-            ('registry_password', 'Enter registry.redhat.io password: '),
+            ('registry_username', 'Enter container registry username: '),
+            ('registry_password', 'Enter container registry password: '),
             ('server_password', 'Enter server password: '),
             ('db_password', 'Enter database password: ')
         ])


### PR DESCRIPTION
closes #73 

---

# Testing
### Upstream
The main test here is to check and make sure that the installer still works upstream even with the variable name changes, and the new `db_image_name` variable for postgres.

- [x] Test to make sure the upstream installer works.

### Downstream
The main way to test this pr will be to test it downstream. I will create a WIP pr downstream to help with this. 

---

**Additional Notes:**
1) While working on this I realized that we want to be very careful when it comes to defaulting values in the cli arg parser for downstream only args. Defaulting values in the cli means that if we run into a situation where those defaults are no longer valid, we would have to cut an upstream release in order to change downstream defaults. Whereas if we leave the defaulting at the playbook level, we could fix the bad defaults without having to cut an upstream release.
