### PR TITLE
Add support for CentOS 8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ help:
 # Internal subcommands that the user should not call
 create-test-dirs:
 	mkdir -p test/packages
-	@for os in rhel6 rhel7 rhel8 centos6 centos7; do \
+	@for os in rhel6 rhel7 rhel8 centos6 centos7 centos8; do \
 		set -x; \
 		mkdir -p test/$$os/install/; \
 		mkdir -p test/$$os/config/rhel6; \
@@ -45,7 +45,7 @@ create-test-dirs:
 	done
 
 copy-vm-helper-files:
-	for os in rhel6 rhel7 rhel8 centos6 centos7 ; do cp -vrf vm_helper_files/ test/$$os; done
+	for os in rhel6 rhel7 rhel8 centos6 centos7 centos8; do cp -vrf vm_helper_files/ test/$$os; done
 
 # Internal subcommands that the user should not call
 copy-config:
@@ -55,7 +55,7 @@ copy-config:
 		tar -xvf tools_config.tar.gz | true; \
 		cp -rf tools_config/* test/helpers | true; \
 		rm -rf tools_config/ | true; \
-		for dest in test/rhel8 test/rhel7 test/rhel6 test/centos6 test/centos7 ; do cp -vrf test/helpers/* $$dest | true; done; \
+		for dest in test/rhel8 test/rhel7 test/rhel6 test/centos6 test/centos7 test/centos8 ; do cp -vrf test/helpers/* $$dest | true; done; \
 		rm -rf test/helpers | true; \
 		set +x; \
 	else \
@@ -64,7 +64,7 @@ copy-config:
 
 # Internal subcommands that the user should not call
 copy-packages:
-	for os in rhel6 rhel7 rhel8 centos6 centos7 ; do cp -vrf test/packages/ test/$$os/install/packages/ ; done
+	for os in rhel6 rhel7 rhel8 centos6 centos7 centos8; do cp -vrf test/packages/ test/$$os/install/packages/ ; done
 
 # Internal subcommands that the user should not call
 local-server-image: download-postgres
@@ -119,10 +119,10 @@ download-qpc-tools:
 	done
 
 copy-qpc-tools-local: manifest
-	for os in rhel6 rhel7 rhel8 centos6 centos7 ; do cp -vrf qpc_tools test/$$os; done
-	for os in rhel6 rhel7 rhel8 centos6 centos7 ; do cp -vrf setup.py test/$$os; done
-	for os in rhel6 rhel7 rhel8 centos6 centos7 ; do cp -vrf MANIFEST.in test/$$os; done
-	for os in rhel6 rhel7 rhel8 centos6 centos7 ; do cp -vrf bin test/$$os; done
+	for os in rhel6 rhel7 rhel8 centos6 centos7 centos8 ; do cp -vrf qpc_tools test/$$os; done
+	for os in rhel6 rhel7 rhel8 centos6 centos7 centos8 ; do cp -vrf setup.py test/$$os; done
+	for os in rhel6 rhel7 rhel8 centos6 centos7 centos8 ; do cp -vrf MANIFEST.in test/$$os; done
+	for os in rhel6 rhel7 rhel8 centos6 centos7 centos8 ; do cp -vrf bin test/$$os; done
 
 copy-qpc-tools:
 	@for os_version in 6 7 8 ; do \
@@ -190,6 +190,9 @@ test-centos-6:
 
 test-centos-7:
 	vagrant up vcentos7;vagrant ssh vcentos7
+
+test-centos-8:
+	vagrant up vcentos8;vagrant ssh vcentos8
 
 clean-local-cli:
 	rm -rf dist/ build/ qpc_tools.egg-info/

--- a/Makefile
+++ b/Makefile
@@ -126,10 +126,10 @@ download-qpc-tools:
 	done
 
 copy-qpc-tools-local: manifest
-	for os in rhel6 rhel7 rhel8 centos6 centos7 centos8 ; do cp -vrf qpc_tools test/$$os; done
-	for os in rhel6 rhel7 rhel8 centos6 centos7 centos8 ; do cp -vrf setup.py test/$$os; done
-	for os in rhel6 rhel7 rhel8 centos6 centos7 centos8 ; do cp -vrf MANIFEST.in test/$$os; done
-	for os in rhel6 rhel7 rhel8 centos6 centos7 centos8 ; do cp -vrf bin test/$$os; done
+	for os in $(PLATFORMS) ; do cp -vrf qpc_tools test/$$os; done
+	for os in $(PLATFORMS) ; do cp -vrf setup.py test/$$os; done
+	for os in $(PLATFORMS) ; do cp -vrf MANIFEST.in test/$$os; done
+	for os in $(PLATFORMS) ; do cp -vrf bin test/$$os; done
 
 copy-qpc-tools:
 	@for os_version in $(PLATFORM_VERSIONS) ; do \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,12 @@
 DATE = $(shell date)
 PYTHON = $(shell which python)
 TOPDIR = $(shell pwd)
+
+# PLATFORMS to be used in the setup routines and test-all target
+PLATFORMS = rhel6 rhel7 rhel8 centos6 centos7 centos8
+PLATFORM_VERSIONS = 6 7 8
+
+
 # Required for a work around in the spec file
 pandoc = pandoc
 .PHONY: install
@@ -24,6 +30,7 @@ help:
 	@echo "  test-rhel-8                                    Launch the RHEL 8 VM for testing"
 	@echo "  test-centos-6                                  Launch the CentOS 6 VM for testing"
 	@echo "  test-centos-7                                  Launch the CentOS 7 VM for testing"
+	@echo "  test-centos-8                                  Launch the CentOS 8 VM for testing"
 	@echo "  manpage                                        Create the manpage"
 	@echo "  install                                        Install the qpc-tools CLI egg"
 	@echo "  lint                                           Run the flake8/pylint linter"
@@ -35,7 +42,7 @@ help:
 # Internal subcommands that the user should not call
 create-test-dirs:
 	mkdir -p test/packages
-	@for os in rhel6 rhel7 rhel8 centos6 centos7 centos8; do \
+	@for os in $(PLATFORMS); do \
 		set -x; \
 		mkdir -p test/$$os/install/; \
 		mkdir -p test/$$os/config/rhel6; \
@@ -45,7 +52,7 @@ create-test-dirs:
 	done
 
 copy-vm-helper-files:
-	for os in rhel6 rhel7 rhel8 centos6 centos7 centos8; do cp -vrf vm_helper_files/ test/$$os; done
+	for os in $(PLATFORMS); do cp -vrf vm_helper_files/ test/$$os; done
 
 # Internal subcommands that the user should not call
 copy-config:
@@ -64,7 +71,7 @@ copy-config:
 
 # Internal subcommands that the user should not call
 copy-packages:
-	for os in rhel6 rhel7 rhel8 centos6 centos7 centos8; do cp -vrf test/packages/ test/$$os/install/packages/ ; done
+	for os in $(PLATFORMS); do cp -vrf test/packages/ test/$$os/install/packages/ ; done
 
 # Internal subcommands that the user should not call
 local-server-image: download-postgres
@@ -88,7 +95,7 @@ endif
 # Internal subcommands that the user should not call
 download-qpc-cli:
 	mkdir -p test/cli_packages
-	@for os_version in 6 7 8 ; do \
+	@for os_version in $(PLATFORM_VERSIONS) ; do \
 		set -x; \
 		if [[ "$(cli_version)" = "" || "$(cli_version)" = "latest" ]]; then \
 			curl -k -SL https://github.com/quipucords/qpc/releases/latest/download/qpc.el$$os_version.noarch.rpm -o test/cli_packages/qpc.el$$os_version.noarch.rpm; \
@@ -99,7 +106,7 @@ download-qpc-cli:
 	done
 
 copy-qpc-cli:
-	@for os_version in 6 7 8 ; do \
+	@for os_version in $(PLATFORM_VERSIONS) ; do \
 		set -x; \
 		cp -f test/cli_packages/qpc.el$$os_version.noarch.rpm test/rhel$$os_version/install/packages/; \
 		cp -f test/cli_packages/qpc.el$$os_version.noarch.rpm test/centos$$os_version/install/packages/; \
@@ -108,7 +115,7 @@ copy-qpc-cli:
 
 download-qpc-tools:
 	mkdir -p test/tools_packages
-	@for os_version in 6 7 8 ; do \
+	@for os_version in $(PLATFORM_VERSIONS) ; do \
 		set -x; \
 		if [[ "$(tools_version)" = "" || "$(tools_version)" = "latest" ]]; then \
 			curl -k -SL https://github.com/quipucords/qpc-tools/releases/latest/download/qpc-tools.el$$os_version.noarch.rpm -o test/tools_packages/qpc-tools.el$$os_version.noarch.rpm; \
@@ -125,7 +132,7 @@ copy-qpc-tools-local: manifest
 	for os in rhel6 rhel7 rhel8 centos6 centos7 centos8 ; do cp -vrf bin test/$$os; done
 
 copy-qpc-tools:
-	@for os_version in 6 7 8 ; do \
+	@for os_version in $(PLATFORM_VERSIONS) ; do \
 		set -x; \
 		cp -f test/tools_packages/qpc-tools.el$$os_version.noarch.rpm test/rhel$$os_version/install/; \
 		cp -f test/tools_packages/qpc-tools.el$$os_version.noarch.rpm test/centos$$os_version/install/; \

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,24 +13,32 @@ Vagrant.configure("2") do |config|
     rhel7.vm.synced_folder "./test/rhel7/", "/qpc_tools", :mount_options => ["dmode=777", "fmode=777"]
   end
 
+  config.vm.define "vrhel8" do |rhel8|
+    rhel8.vm.box = "generic/rhel8"
+    rhel8.vm.hostname = "vrhel8"
+    rhel8.vm.network "forwarded_port", guest: 9443, host: 8752, host_ip:"127.0.0.1"
+    rhel8.vm.synced_folder "./test/rhel8/", "/qpc_tools", :mount_options => ["dmode=777", "fmode=777"]
+  end
+
   config.vm.define "vcentos6" do |centos6|
     centos6.vm.box = "geerlingguy/centos6"
     centos6.vm.hostname = "vcentos6"
-    centos6.vm.network "forwarded_port", guest: 9443, host: 8752
+    centos6.vm.network "forwarded_port", guest: 9443, host: 8753
     centos6.vm.synced_folder "./test/centos6/", "/qpc_tools", :mount_options => ["dmode=777", "fmode=777"]
   end
 
   config.vm.define "vcentos7" do |centos7|
     centos7.vm.box = "geerlingguy/centos7"
     centos7.vm.hostname = "vcentos7"
-    centos7.vm.network "forwarded_port", guest: 9443, host: 8753
+    centos7.vm.network "forwarded_port", guest: 9443, host: 8754
     centos7.vm.synced_folder "./test/centos7/", "/qpc_tools", :mount_options => ["dmode=777", "fmode=777"]
   end
 
-  config.vm.define "vrhel8" do |rhel8|
-    rhel8.vm.box = "generic/rhel8"
-    rhel8.vm.hostname = "vrhel8"
-    rhel8.vm.network "forwarded_port", guest: 9443, host: 8754, host_ip:"127.0.0.1"
-    rhel8.vm.synced_folder "./test/rhel8/", "/qpc_tools", :mount_options => ["dmode=777", "fmode=777"]
+  config.vm.define "vcentos8" do |centos8|
+    centos8.vm.box = "geerlingguy/centos8"
+    centos8.vm.hostname = "vcentos8"
+    centos8.vm.network "forwarded_port", guest: 9443, host: 8755
+    centos8.vm.synced_folder "./test/centos8/", "/qpc_tools", :mount_options => ["dmode=777", "fmode=777"]
   end
+
 end

--- a/launch_vms.sh
+++ b/launch_vms.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -x
 export SCRIPT_HOME=$PWD
-declare -a arr=("centos6" "centos7" "rhel6" "rhel7" "rhel8")
+declare -a arr=("centos6" "centos7" "centos8" "rhel6" "rhel7" "rhel8")
 
 # OSX only
 [ `uname -s` != "Darwin" ] && echo 'OS X Only' &&return

--- a/qpc_tools/cli/ansible/install/roles/init/tasks/validate_params.yml
+++ b/qpc_tools/cli/ansible/install/roles/init/tasks/validate_params.yml
@@ -1,9 +1,9 @@
 ---
 
-- name: Fail if running on machines other than RHEL 6/7/8 and CentOS 6/7
+- name: Fail if running on machines other than RHEL 6/7/8 and CentOS 6/7/8
   fail:
-    msg: "This is not a supported system for installation. Must be RHEL 6/7/8 or CentOS 6/7."
-  when: not (is_rhel_centos_6 or is_rhel_centos_7 or is_rhel8)
+    msg: "This is not a supported system for installation. Must be RHEL 6/7/8 or CentOS 6/7/8."
+  when: not (is_rhel_centos_6 or is_rhel_centos_7 or is_rhel_centos_8)
 
 - name: Fail if yum command is not found
   fail:

--- a/qpc_tools/cli/ansible/install/roles/init/tasks/validate_params.yml
+++ b/qpc_tools/cli/ansible/install/roles/init/tasks/validate_params.yml
@@ -16,3 +16,11 @@
   file:
     path: "{{home_dir}}"
     state: directory
+
+- name: Validate Quipucords CLI version compatibility with RHEL 8
+  fail:
+    msg: "Quipucords CLI {{ cli_version }} cannot be installed on RHEL 8.  RHEL 8 requires version 0.9.1 or newer."
+  when:
+  - cli_version is defined
+  - cli_version < '0.9.1'
+  - is_rhel_centos_8|bool

--- a/qpc_tools/server/ansible/install/roles/init/tasks/validate_params.yml
+++ b/qpc_tools/server/ansible/install/roles/init/tasks/validate_params.yml
@@ -1,9 +1,9 @@
 ---
 
-- name: Fail if running on machines other than RHEL 6/7/8 and CentOS 6/7
+- name: Fail if running on machines other than RHEL 6/7/8 and CentOS 6/7/8
   fail:
-    msg: "This is not a supported system for installation. Must be RHEL 6/7/8 or CentOS 6/7."
-  when: not (is_rhel_centos_6 or is_rhel_centos_7 or is_rhel8)
+    msg: "This is not a supported system for installation. Must be RHEL 6/7/8 or CentOS 6/7/8."
+  when: not (is_rhel_centos_6 or is_rhel_centos_7 or is_rhel_centos_8)
 
 - name: Fail if yum command is not found
   fail:

--- a/qpc_tools/server/ansible/install/roles/init/tasks/validate_params.yml
+++ b/qpc_tools/server/ansible/install/roles/init/tasks/validate_params.yml
@@ -30,3 +30,11 @@
   file:
     path: "{{home_dir}}"
     state: directory
+
+- name: Validate Quipucords server version compatibility with RHEL 8
+  fail:
+    msg: "Quipucords server {{ server_version }} cannot be installed on RHEL 8.  RHEL 8 requires version 0.9.1 or newer."
+  when:
+  - server_version is defined
+  - server_version < '0.9.1'
+  - is_rhel_centos_8|bool

--- a/qpc_tools/server/ansible/install/roles/server/tasks/validate_params.yml
+++ b/qpc_tools/server/ansible/install/roles/server/tasks/validate_params.yml
@@ -14,14 +14,6 @@
     - not open_port|lower == 'true'
     - not open_port|lower == 'false'
 
-- name: Validate Quipucords server version compatibility with RHEL 8
-  fail:
-    msg: "Quipucords server {{ server_version }} cannot be installed on RHEL 8.  RHEL 8 requires version 0.9.1 or newer."
-  when:
-  - server_version is defined
-  - server_version < '0.9.1'
-  - is_rhel_centos_8|bool
-
 - name: Fail if podman command not found when podman is being used instead of docker
   fail:
     msg: "Podman command not found"

--- a/qpc_tools/server/ansible/install/roles/server/tasks/validate_params.yml
+++ b/qpc_tools/server/ansible/install/roles/server/tasks/validate_params.yml
@@ -20,7 +20,7 @@
   when:
   - server_version is defined
   - server_version < '0.9.1'
-  - is_rhel8|bool
+  - is_rhel_centos_8|bool
 
 - name: Fail if podman command not found when podman is being used instead of docker
   fail:

--- a/vm_helper_files/Makefile
+++ b/vm_helper_files/Makefile
@@ -24,7 +24,6 @@ offline-prep: setup
 		yum install -y libcgroup; \
 		yum install -y yum-utils; \
 		yum install -y ansible; \
-		yum install -y docker; \
 		yum install -y podman; \
 		yum install -y epel-release; \
 		yum install -y python36; \
@@ -39,6 +38,7 @@ offline-prep: setup
 		rpm -Uvh --force "docker-engine-1.7.1-1.el6.x86_64.rpm"; \
 		yum install -y python34; \
 		yum install -y python34-requests; \
+		yum install -y python34-setuptools; \
 	else \
 		echo "Running 8"; \
 		yum install -y epel-release; \

--- a/vm_helper_files/Makefile
+++ b/vm_helper_files/Makefile
@@ -41,6 +41,7 @@ offline-prep: setup
 		yum install -y python34-requests; \
 	else \
 		echo "Running 8"; \
+		yum install -y epel-release; \
 		yum install -y ansible; \
 		yum install -y podman; \
 		yum install -y python36; \
@@ -64,6 +65,7 @@ online-prep: setup
 		yum install -y python34-setuptools; \
 	else \
 		echo "Running 8"; \
+		yum install -y epel-release; \
 		yum install -y ansible; \
 		yum install -y python36; \
 	fi


### PR DESCRIPTION
Closes #2 

Note you can only test the local installer in this PR as we have not released qpc-tools.

## Server Tests

- [x] Online latest server release (0.9.1)
- [x] Online previous server release (set release to 0.9.1)
- [x] Online unsupported server release (0.9.0)
- [x] Offline latest server release (0.9.1)

## CLI Tests

- [x] Online latest cli release (0.9.2)
- [x] Online previous cli release (set release to 0.9.1)
- [x] Online unsupported cli release (0.9.0)
- [x] Offline latest cli release (0.9.2)