### PR TITLE
Fix server `validate_server_install` failure

### DIFF
--- a/qpc_tools/server/ansible/install/roles/server_podman/tasks/install_online.yml
+++ b/qpc_tools/server/ansible/install/roles/server_podman/tasks/install_online.yml
@@ -70,6 +70,11 @@
     - have_qpc_docker_containers
     - not have_qpc_podman_containers
 
+- name: Restart the PostgreSQL container
+  include_role:
+    name: server_podman
+    tasks_from: restart_postgres_container
+
 - name: Validate that the Quipucords server is up and running
   include_role:
     name: server

--- a/qpc_tools/server/ansible/install/roles/server_podman/tasks/restart_postgres_container.yml
+++ b/qpc_tools/server/ansible/install/roles/server_podman/tasks/restart_postgres_container.yml
@@ -1,0 +1,5 @@
+---
+
+- name: Stop PostgreSQL container with Podman
+  shell: "podman restart qpc-db"
+  become: true


### PR DESCRIPTION
This change is an attempt to fix a failure quipucords of the quipucords server to start up during the podman install due to the Postgres service not starting cleanly.

After some trial and error, I was able to fix the issue by adding a restart of the Postgres container just before attempting to validate the server.  

Will continue to debug to find the root cause of the Postgres failure, but wanted to get a PR created with working code in the meantime.

The install was run on RHEL 8.4